### PR TITLE
Footer: Textboard version/git commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
+VERSION := Commit\ $(shell git show -s --format=%h)
 ifeq ($(PRODUCTION), 1)
-    CFLAGS=-lm -lpthread -Wall -O1 -DPRODUCTION
+    CFLAGS=-lm -lpthread -Wall -O1 -DPRODUCTION -DFOOTER_VERSION=\"$(VERSION)\"
 else
-    CFLAGS=-lm -lpthread -Wall -g -O0
+    CFLAGS=-lm -lpthread -Wall -g -O0 -DFOOTER_VERSION=\"$(VERSION)\"
 endif
 SOURCES=src/server.c src/posts.c src/helpers.c src/handler.c src/database.c
 .PHONY: server src/static_files.h $(SOURCES)

--- a/src/config.h
+++ b/src/config.h
@@ -6,7 +6,7 @@
 
 // Name of the board software. Build scripts append commit hash.
 #ifndef FOOTER_VERSION
-#define FOOTER_VERSION "texboard"
+#define FOOTER_VERSION "textboard"
 #endif
 
 // Database

--- a/src/config.h
+++ b/src/config.h
@@ -4,6 +4,11 @@
 // Name of the site (will be used in title/header)
 #define SITE_NAME "/c/chan"
 
+// Name of the board software. Build scripts append commit hash.
+#ifndef FOOTER_VERSION
+#define FOOTER_VERSION "texboard"
+#endif
+
 // Database
 // Where the database will be located relative to the server binary
 #define DATABASE_FILE "database.csv"

--- a/src/handler.c
+++ b/src/handler.c
@@ -97,7 +97,8 @@ CNT_TEXT_HEADER \
             digits( // Content-Length: ??
                 strlen(INDEX_FILE_HEADER) +
                 (html == NULL ? 0 : strlen(html)) +
-                strlen(FOOTER_FILE)
+                strlen(FOOTER_FILE) +
+                strlen(FOOTER_VERSION)
             ) +
             1 + // '\n'
             strlen(date) + // Date: [date]
@@ -105,6 +106,7 @@ CNT_TEXT_HEADER \
             strlen(INDEX_FILE_HEADER) + // index file
             (html == NULL ? 0 : strlen(html)) + // posts
             strlen(FOOTER_FILE) +
+            strlen(FOOTER_VERSION) +
             2; // '\0'
         
         malloc_or_fail(char *, response, length, {
@@ -116,7 +118,7 @@ CNT_TEXT_HEADER \
             RESPONSE_HEADER "%li\n%s\n\n" INDEX_FILE_HEADER "%s" FOOTER_FILE,
             length,
             date,
-            html == NULL ? "" : html);
+            html == NULL ? "" : html, FOOTER_VERSION);
         #ifndef PRODUCTION
         printf("RESPONSE\n%s", response);
         #endif
@@ -157,7 +159,8 @@ CNT_TEXT_HEADER \
                     strlen(INDEX_FILE_HEADER) +
                     strlen(html) +
                     (replies_html == NULL ? 0 : strlen(replies_html)) +
-                    strlen(FOOTER_FILE)
+                    strlen(FOOTER_FILE) +
+                    strlen(FOOTER_VERSION)
                 ) +
                 1 + // \n
                 strlen(date) + // Date: [date]
@@ -167,6 +170,7 @@ CNT_TEXT_HEADER \
                 strlen(html) + // post
                 (replies_html == NULL ? 0 : strlen(replies_html)) +
                 strlen(FOOTER_FILE) +
+                strlen(FOOTER_VERSION) +
                 2; // '\0'
         
             malloc_or_fail(char *, response, length, {
@@ -181,7 +185,8 @@ CNT_TEXT_HEADER \
                 date,
                 post_id_str,
                 html,
-                (replies_html == NULL ? "" : replies_html));
+                (replies_html == NULL ? "" : replies_html),
+                FOOTER_VERSION);
             #ifndef PRODUCTION
             printf("RESPONSE\n%s", response);
             #endif

--- a/static/FOOTER_FILE.html
+++ b/static/FOOTER_FILE.html
@@ -2,6 +2,7 @@
     <center style='text-align:center;'>
         <p><a href='https://github.com/shwsh/textboard'>Github</a></p>
         <p><small>This site is best viewed on w3m, on a *nix tty, on a 640x480 CRT monitor,</small><br><small>in a dimly-lit room beside a window at night with all doors locked.</small></p>
+        <p><small>%s</small></p>
     </center>
 </body>
 </html>


### PR DESCRIPTION
This adds the current commit hash to the footer like so:

![scrot](https://0x0.st/sTqX.png)

I think it fits the theme and is useful especially in early dev stage with the hosted/public instance. Also my C is rusty af, hope I did the buffer size calculations right, no bulli c:

The option can be overridden by passing `VERSION` like this: `make VERSION=custom-textboard321`.

