### PR TITLE
Fix alpine docker build errors

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <netinet/in.h>
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
Noticed the docker image doesn't build anymore due to time related data structures missing in `src/server.c`, resulting in the following error: [(Gist Link)](https://gist.github.com/fuerbringer/9ca93a5a4f6cd8dbc4e2f3e297dca6de/raw/c8f7eed6d0c8c898c9b5ec7106264aa1b45b8ff0/gistfile1.txt)

Including the `<sys/time.h>` header file fixes that problem.

Note that this patch only builds with the dockerfile from #1. So merge that too :>

