### PR TITLE
Allow direct post and reply linking

### DIFF
--- a/src/posts.c
+++ b/src/posts.c
@@ -21,7 +21,7 @@
 \
     snprintf(x, length, element, \
             post->subject, post->author, time_utc, time, \
-            post->id, post->id, post->replies->length, post->comment);
+            post->id, post->id, post->id, post->replies->length, post->comment);
 
 #define GUESS_POST_RENDER_LENGTH(element) /* generous guesstimate */ \
     (strlen(element) + \

--- a/static/POST_ELEMENT.html
+++ b/static/POST_ELEMENT.html
@@ -3,7 +3,7 @@
         <b class='subject'>%s</b>
         <span class='name'>%s</span>
         <time datetime='%s'>%s</time>
-        <a href='/post/%i' class='id'>#%i</a>
+        <a href='/post/%i#%i' class='id'>#%i</a>
         <span class='replies'>(%li)</span>
     </p>
     <p class='comment'>%s</p>

--- a/static/POST_REPLY_ELEMENT.html
+++ b/static/POST_REPLY_ELEMENT.html
@@ -3,7 +3,7 @@
         <b class='subject'>%s</b>
         <span class='name'>%s</span>
         <time datetime='%s'>%s</time>
-        <a id='%i' class='id'>#%i</a>
+        <a href="#%i" id='%i' class='id'>#%i</a>
         <span class='replies'>(%li)</span>
     </p>
     <p class='comment'>%s</p>


### PR DESCRIPTION
This patch allows individual posts and replies to be directly linked to. `http://textboard:8080/post/1#13` would for example directly jump to post nr. 13 in thread nr. 1.